### PR TITLE
Fix syntax highlighting

### DIFF
--- a/_site.yml
+++ b/_site.yml
@@ -47,7 +47,7 @@ output:
       code_download: true
       df_print: paged
       theme: flatly
-      highligt: tango
+      highlight: tango
       toc: true
       toc_float: true
       number_sections: true


### PR DESCRIPTION
Typo from the template repository. 
See https://github.com/statOmics/Rmd-website/commit/1048f8d86f7830712e4a99ca499ad18f4c2f5486.